### PR TITLE
Fix missing ESPNOW_TYPE_SECURITY_DATA

### DIFF
--- a/components/espnow/include/espnow.h
+++ b/components/espnow/include/espnow.h
@@ -88,6 +88,7 @@ typedef struct {
         bool data;
         bool sec_status;
         bool sec;
+        bool sec_data;
         bool reserved;
     } receive_enable;            /**< Receive status of packet type */
 } espnow_config_t;
@@ -112,6 +113,7 @@ typedef struct {
                 .data          = 0, \
                 .sec_status    = 0, \
                 .sec           = 0, \
+                .sec_data      = 0, \
                 .reserved      = 0, \
                 }, \
     }

--- a/components/espnow/src/espnow.c
+++ b/components/espnow/src/espnow.c
@@ -906,7 +906,7 @@ esp_err_t espnow_init(const espnow_config_t *config)
         espnow_sec_init(g_espnow_sec);
     }
 
-    uint8_t *enable = (uint8_t *)&config->receive_enable;
+    bool *enable = (bool *)&config->receive_enable;
     for (int i = 0; i < ESPNOW_TYPE_MAX; ++i) {
         g_recv_handle[i].enable = enable[i];
     }


### PR DESCRIPTION
https://github.com/espressif/esp-now/blob/31c6121392e4e614ef8f379d340ab84fc5c6ba9d/components/espnow/include/espnow.h#L129