### PR TITLE
fix: Fix ota spi write error when device encryption is enabled (AEGHB-262)

### DIFF
--- a/src/espnow/src/espnow.c
+++ b/src/espnow/src/espnow.c
@@ -283,7 +283,7 @@ void espnow_recv_cb(const uint8_t *addr, const uint8_t *data, int size)
         uint32_t *magic = ESP_MALLOC(sizeof(uint32_t));
         *magic = frame_head->magic;
 
-        if (!g_ack_queue || queue_over_write(ESPNOW_EVENT_RECV_ACK, magic, sizeof(uint32_t), NULL, 0) != pdPASS) {
+        if (!g_ack_queue || queue_over_write(ESPNOW_EVENT_RECV_ACK, magic, sizeof(uint32_t), NULL, g_espnow_config->send_max_timeout) != pdPASS) {
             ESP_LOGW(TAG, "[%s, %d] Send event queue failed", __func__, __LINE__);
             ESP_FREE(magic);
             return ;
@@ -335,7 +335,7 @@ void espnow_recv_cb(const uint8_t *addr, const uint8_t *data, int size)
             q_data->rx_ctrl.channel = frame_head->channel;
         }
 
-        if (queue_over_write(ESPNOW_EVENT_RECEIVE, q_data, sizeof(espnow_pkt_t) + espnow_data->size, NULL, 0) != pdPASS) {
+        if (queue_over_write(ESPNOW_EVENT_RECEIVE, q_data, sizeof(espnow_pkt_t) + espnow_data->size, NULL, g_espnow_config->send_max_timeout) != pdPASS) {
             ESP_LOGW(TAG, "[%s, %d] Send event queue failed", __func__, __LINE__);
             ESP_FREE(q_data);
             return ;
@@ -359,7 +359,7 @@ FORWARD_DATA:
             q_data->frame_head.forward_ttl--;
         }
 
-        if (!g_espnow_queue || queue_over_write(ESPNOW_EVENT_FORWARD, q_data, size, NULL, 0) != pdPASS) {
+        if (!g_espnow_queue || queue_over_write(ESPNOW_EVENT_FORWARD, q_data, size, NULL, g_espnow_config->send_max_timeout) != pdPASS) {
             ESP_LOGW(TAG, "[%s, %d] Send event queue failed", __func__, __LINE__);
             ESP_FREE(q_data);
             return ;

--- a/src/ota/espnow_ota_initiator.c
+++ b/src/ota/espnow_ota_initiator.c
@@ -280,7 +280,7 @@ static esp_err_t espnow_ota_request_status(uint8_t (*progress_array)[ESPNOW_OTA_
         .security         = CONFIG_ESPNOW_OTA_SECURITY,
     };
 
-    for (int i = 0, wait_ticks = pdMS_TO_TICKS(500); i < 3 && response_num > 0; ++i, wait_ticks = pdMS_TO_TICKS(100)) {
+    for (int i = 0, wait_ticks = pdMS_TO_TICKS(1000); i < 3 && response_num > 0; ++i, wait_ticks = pdMS_TO_TICKS(500)) {
         if (espnow_send(ESPNOW_DATA_TYPE_OTA_DATA, ESPNOW_ADDR_GROUP_OTA, status,
                         sizeof(espnow_ota_status_t), &status_frame, portMAX_DELAY) != ESP_OK) {
             ESP_LOGW(TAG, "Request devices upgrade status");

--- a/src/ota/include/espnow_ota.h
+++ b/src/ota/include/espnow_ota.h
@@ -56,7 +56,7 @@ extern "C" {
  * @brief Firmware subcontract upgrade
  */
 #define ESPNOW_OTA_PROGRESS_MAX_SIZE           (ESPNOW_DATA_LEN - 30)  /**< Maximum length of the array which indicates the packet processed */
-#define ESPNOW_OTA_PACKET_MAX_SIZE             (ESPNOW_DATA_LEN - 4)  /**< Maximum length of a single packet transmitted */
+#define ESPNOW_OTA_PACKET_MAX_SIZE             ((ESPNOW_DATA_LEN - 4) - (ESPNOW_DATA_LEN -4) % 16)  /**< Maximum length of a single packet transmitted */
 #define ESPNOW_OTA_PACKET_MAX_NUM              (4 * 1024 * 1024/ ESPNOW_OTA_PACKET_MAX_SIZE) /**< The maximum number of packets */
 
 /**


### PR DESCRIPTION
This pull request should fix following issue: https://github.com/espressif/esp-now/issues/79