### PR TITLE
Fix "warning: initialization discards 'const' qualifier from pointer target type" (AEGHB-453)

### DIFF
--- a/src/debug/src/commands/cmd_espnow.c
+++ b/src/debug/src/commands/cmd_espnow.c
@@ -176,7 +176,7 @@ static int scan_func(int argc, char **argv)
 
     uint8_t addr[ESPNOW_ADDR_LEN] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 
-    char *data = "beacon";
+    const char *data = "beacon";
     espnow_frame_head_t frame_head = {
         .retransmit_count = ESPNOW_RETRANSMIT_MAX_COUNT,
         .broadcast = true,

--- a/src/debug/src/commands/cmd_wifi_sniffer.c
+++ b/src/debug/src/commands/cmd_wifi_sniffer.c
@@ -53,7 +53,7 @@ typedef enum {
 } sniffer_wlan_filter_t;
 
 typedef struct {
-    char *filter_name;
+    const char *filter_name;
     uint32_t filter_val;
 } wlan_filter_table_t;
 
@@ -114,7 +114,7 @@ static uint32_t hash_func(const char *str, uint32_t max_num)
 
 static void create_wifi_filter_hashtable()
 {
-    char *wifi_filter_keys[SNIFFER_WLAN_FILTER_MAX] = {"mgmt", "data", "ctrl", "misc", "mpdu", "ampdu"};
+    const char *wifi_filter_keys[SNIFFER_WLAN_FILTER_MAX] = {"mgmt", "data", "ctrl", "misc", "mpdu", "ampdu"};
     uint32_t wifi_filter_values[SNIFFER_WLAN_FILTER_MAX] = { WIFI_PROMIS_FILTER_MASK_MGMT, WIFI_PROMIS_FILTER_MASK_DATA,
                                                              WIFI_PROMIS_FILTER_MASK_CTRL, WIFI_PROMIS_FILTER_MASK_MISC,
                                                              WIFI_PROMIS_FILTER_MASK_DATA_MPDU, WIFI_PROMIS_FILTER_MASK_DATA_AMPDU

--- a/src/utils/src/espnow_timesync.c
+++ b/src/utils/src/espnow_timesync.c
@@ -32,7 +32,7 @@ esp_err_t espnow_timesync_start()
         return ESP_OK;
     }
 
-    char *sntp_server_name = CONFIG_ESP_SNTP_SERVER_NAME;
+    const char *sntp_server_name = CONFIG_ESP_SNTP_SERVER_NAME;
 
     ESP_LOGI(TAG, "Initializing SNTP. Using the SNTP server: %s", sntp_server_name);
     sntp_setoperatingmode(SNTP_OPMODE_POLL);


### PR DESCRIPTION
Small change, but silences the compiler when `COMPILER_WARN_WRITE_STRINGS` is enabled