### PR TITLE
fix: Compilation with esp-idf 5.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,15 @@ list(APPEND srcs         "src/utils/src/espnow_mem.c"
                          "src/utils/src/espnow_utils.c")
 list(APPEND include_dirs "src/utils/include")
 
-list(APPEND requires "spi_flash" "nvs_flash" "esp_timer" "esp_wifi" "driver")
+list(APPEND requires "spi_flash" "nvs_flash" "esp_timer" "esp_wifi")
+# only need to append these if ESP-IDF is >= 5.4
+idf_build_get_property(IDF_VERSION_MAJOR IDF_VERSION_MAJOR)
+idf_build_get_property(IDF_VERSION_MINOR IDF_VERSION_MINOR)
+if(IDF_VERSION_MAJOR GREATER 5 OR (IDF_VERSION_MAJOR EQUAL 5 AND IDF_VERSION_MINOR GREATER_EQUAL 4))
+     list(APPEND requires "esp_driver_gpio" "esp_driver_uart" "esp_driver_usb_serial_jtag")
+else()
+     list(APPEND requires "driver")
+endif()
 
 idf_component_register(SRCS "${srcs}"
                        INCLUDE_DIRS "${include_dirs}"

--- a/src/espnow/src/espnow.c
+++ b/src/espnow/src/espnow.c
@@ -401,16 +401,27 @@ EXIT:
 }
 
 /**< callback function of sending ESPNOW data */
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 1)
+void espnow_send_cb(const esp_now_send_info_t *tx_info, esp_now_send_status_t status)
+#else
 void espnow_send_cb(const uint8_t *addr, esp_now_send_status_t status)
+#endif
 {
     if (g_buffered_num) {
         g_buffered_num --;
     }
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 1)
+    if (!tx_info || !g_event_group) {
+        ESP_LOGW(TAG, "Send cb args error, tx_info is NULL");
+        return ;
+    }
+#else
     if (!addr || !g_event_group) {
         ESP_LOGW(TAG, "Send cb args error, addr is NULL");
         return ;
     }
+#endif
 
     if (status == ESP_NOW_SEND_SUCCESS) {
         xEventGroupSetBits(g_event_group, SEND_CB_OK);


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

Fixes compilation of esp-now with ESP-IDF v5.5

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

Closes #150 

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

Build the examples.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
